### PR TITLE
Redirige les utilisateurs connectés

### DIFF
--- a/magicauth/forms.py
+++ b/magicauth/forms.py
@@ -27,7 +27,7 @@ class EmailForm(forms.Form):
         token = MagicToken.objects.create(user=user)
         return token
 
-    def send_email(self, request):
+    def send_email(self, request, next_view):
         user_email = self.cleaned_data["email"]
         email_field = magicauth_settings.EMAIL_FIELD
         field_lookup = {f"{email_field}__iexact": user_email}
@@ -37,7 +37,12 @@ class EmailForm(forms.Form):
         html_template = magicauth_settings.EMAIL_HTML_TEMPLATE
         text_template = magicauth_settings.EMAIL_TEXT_TEMPLATE
         from_email = magicauth_settings.FROM_EMAIL
-        context = {"token": token, "user": user, "site": request.site}
+        context = {
+            "token": token,
+            "user": user,
+            "site": request.site,
+            "next_view": next_view,
+        }
         text_message = loader.render_to_string(text_template, context)
         html_message = loader.render_to_string(html_template, context)
         send_mail(

--- a/magicauth/forms.py
+++ b/magicauth/forms.py
@@ -27,7 +27,7 @@ class EmailForm(forms.Form):
         token = MagicToken.objects.create(user=user)
         return token
 
-    def send_email(self, request, next_view):
+    def send_email(self, current_site, next_view):
         user_email = self.cleaned_data["email"]
         email_field = magicauth_settings.EMAIL_FIELD
         field_lookup = {f"{email_field}__iexact": user_email}
@@ -40,7 +40,7 @@ class EmailForm(forms.Form):
         context = {
             "token": token,
             "user": user,
-            "site": request.site,
+            "site": current_site,
             "next_view": next_view,
         }
         text_message = loader.render_to_string(text_template, context)

--- a/magicauth/templates/magicauth/email.txt
+++ b/magicauth/templates/magicauth/email.txt
@@ -1,6 +1,6 @@
 Bonjour {{ user.first_name }} {{ user.last_name }},
 
-Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}
+Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}?next={{ next_view }}
 
 Bonne journée,
 

--- a/magicauth/templates/magicauth/email_sent.html
+++ b/magicauth/templates/magicauth/email_sent.html
@@ -15,7 +15,7 @@
                       <h1>Un email vous a été envoyé pour vous connecter.</h1> Si vous ne le recevez pas, vous pouvez réessayer.
                 </div>
                 <div class="text-center">
-                  <a href="{% url 'magicauth-login' %}" class="btn btn-secondary">Réessayer</a>
+                  <a href="{% url 'magicauth-login' %}?next={{ next_view }}" class="btn btn-secondary">Réessayer</a>
                 </div>
               </div>
           </div>

--- a/magicauth/templates/magicauth/login.html
+++ b/magicauth/templates/magicauth/login.html
@@ -14,21 +14,12 @@
                 {% csrf_token %}
 
                 <div class="card-body p-4">
-                  {% if user.is_authenticated %}
-                    <div class="alert alert-info text-center" role="alert">
-                      Vous êtes déjà connecté
+                  {% if messages %}
+                    <div class="text-center" role="alert">
+                      {% for message in messages %}
+                      <p {% if message.tags %}class="alert alert-{{ message.tags }}"{% endif %}>{{ message }}</p>
+                      {% endfor %}
                     </div>
-                    <div class="text-center">
-                      <a href="{% url LOGGED_IN_REDIRECT_URL_NAME %}" class="btn btn-success">Accédez à l'accueil</a>
-                      <a href="{% url LOGOUT_URL_NAME %}" class="btn btn-warning">Déconnectez-vous</a>
-                    </div>
-                  {% else %}
-                    {% if messages %}
-                      <div class="text-center" role="alert">
-                        {% for message in messages %}
-                          <p {% if message.tags %}class="alert alert-{{ message.tags }}"{% endif %}>{{ message }}</p>
-                        {% endfor %}
-                      </div>
                     {% endif %}
 
                     <div class="form-group">
@@ -42,7 +33,6 @@
                     <div class="form-footer">
                       <button type="submit" class="btn btn-primary btn-block">Valider</button>
                     </div>
-                  {% endif %}
                 </div>
               </form>
             </div>

--- a/magicauth/templates/magicauth/login.html
+++ b/magicauth/templates/magicauth/login.html
@@ -10,7 +10,7 @@
         <div class="my-3 my-md-5">
           <div class="row row-cards">
             <div class="col col-login col-6 mx-auto">
-              <form class="card" action="{% url 'magicauth-login' %}" method="post">
+              <form class="card" method="post">
                 {% csrf_token %}
 
                 <div class="card-body p-4">

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -1,5 +1,5 @@
+import re
 from datetime import timedelta
-
 from django.contrib import messages
 from django.contrib.auth import login
 from django.shortcuts import redirect
@@ -21,7 +21,9 @@ class LoginView(FormView):
     template_name = magicauth_settings.LOGIN_VIEW_TEMPLATE
 
     def get(self, request, *args, **kwargs):
-        next_view = self.request.GET.get("next", f"/{magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME}/")
+        next_view = self.request.GET.get(
+            "next", f"/{magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME}/"
+        )
         if request.user.is_authenticated:
             return redirect(next_view)
 
@@ -75,9 +77,12 @@ class ValidateTokenView(View):
         return token
 
     def get(self, request, *args, **kwargs):
-        url = request.GET.get(
-            "next", reverse_lazy(magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME)
-        )
+
+        full_path = request.get_full_path()
+        rule_for_redirect = re.compile("(.*next=)(.*)")
+        next_view = rule_for_redirect.match(full_path)
+        redirect_default = reverse_lazy(magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME)
+        url = next_view.group(1) if next_view else redirect_default
 
         if request.user.is_authenticated:
             return redirect(url)

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -9,8 +9,6 @@ from django.views.generic import View, FormView, TemplateView
 from magicauth.forms import EmailForm
 from magicauth.models import MagicToken
 from magicauth import settings as magicauth_settings
-import logging
-
 
 
 class LoginView(FormView):
@@ -80,16 +78,12 @@ class ValidateTokenView(View):
 
     def get(self, request, *args, **kwargs):
         full_path = request.get_full_path()
-        logging.warning("## full path : ")
-        logging.warning(full_path)
 
         rule_for_redirect = re.compile("(.*next=)(.*)")
         next_view = rule_for_redirect.match(full_path)
         redirect_default = reverse_lazy(magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME)
         url = next_view.group(2) if next_view else redirect_default
 
-        logging.warning("## url")
-        logging.warning(url)
         if request.user.is_authenticated:
             return redirect(url)
         token_key = kwargs.get("key")

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -52,11 +52,16 @@ class ValidateTokenView(View):
     and either logs in or shows a form to make a new token.
     """
 
-    def get_valid_token(self, key):
+    @staticmethod
+    def get_valid_token(key):
         duration = magicauth_settings.TOKEN_DURATION_SECONDS
-        token = MagicToken.objects.filter(key=key).first()
-        if not token:
+        try:
+            token = MagicToken.objects.get(key=key)
+        except MagicToken.DoesNotExist:
             return None
+        except MagicToken.MultipleObjectsReturned:
+            return None
+
         if token.created < timezone.now() - timedelta(seconds=duration):
             token.delete()
             return None

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -77,13 +77,14 @@ class ValidateTokenView(View):
         return token
 
     def get(self, request, *args, **kwargs):
-
         full_path = request.get_full_path()
+        print("## full path", full_path)
+
         rule_for_redirect = re.compile("(.*next=)(.*)")
         next_view = rule_for_redirect.match(full_path)
         redirect_default = reverse_lazy(magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME)
         url = next_view.group(1) if next_view else redirect_default
-
+        print("## url", url)
         if request.user.is_authenticated:
             return redirect(url)
         token_key = kwargs.get("key")

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -9,6 +9,8 @@ from django.views.generic import View, FormView, TemplateView
 from magicauth.forms import EmailForm
 from magicauth.models import MagicToken
 from magicauth import settings as magicauth_settings
+import logging
+
 
 
 class LoginView(FormView):
@@ -78,13 +80,15 @@ class ValidateTokenView(View):
 
     def get(self, request, *args, **kwargs):
         full_path = request.get_full_path()
-        print("## full path", full_path)
+        logging.warning("## full path : ")
+        logging.warning(full_path)
 
         rule_for_redirect = re.compile("(.*next=)(.*)")
         next_view = rule_for_redirect.match(full_path)
         redirect_default = reverse_lazy(magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME)
         url = next_view.group(1) if next_view else redirect_default
-        print("## url", url)
+        logging.warning("## url")
+        logging.warning(url)
         if request.user.is_authenticated:
             return redirect(url)
         token_key = kwargs.get("key")

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -5,15 +5,13 @@ from django.contrib.auth import login
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.utils import timezone
-from django.views import generic
-
-
+from django.views.generic import View, FormView, TemplateView
 from magicauth.forms import EmailForm
 from magicauth.models import MagicToken
 from magicauth import settings as magicauth_settings
 
 
-class LoginView(generic.FormView):
+class LoginView(FormView):
     """
     The login page. The user enters their email in the form to get a link by email.
     """
@@ -35,7 +33,7 @@ class LoginView(generic.FormView):
         return super().form_valid(form)
 
 
-class EmailSentView(generic.TemplateView):
+class EmailSentView(TemplateView):
     """
     View shown to confirm the email has been sent.
     """

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -35,14 +35,15 @@ class LoginView(FormView):
             "LOGGED_IN_REDIRECT_URL_NAME"
         ] = magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME
         context["LOGOUT_URL_NAME"] = magicauth_settings.LOGOUT_URL_NAME
-        context["next_view"] = self.request.GET.get(
-            "next", f"/{magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME}/"
-        )
         return context
 
     def form_valid(self, form, *args, **kwargs):
-        next_view = self.get_context_data().get("next_view")
-        form.send_email(self.request, next_view)
+        next_view = self.request.GET.get(
+            "next",
+            f"/{magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME}/"
+        )
+        current_site = self.request.site
+        form.send_email(current_site, next_view)
         return super().form_valid(form)
 
 

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -20,6 +20,13 @@ class LoginView(FormView):
     success_url = reverse_lazy("magicauth-email-sent")
     template_name = magicauth_settings.LOGIN_VIEW_TEMPLATE
 
+    def get(self, request, *args, **kwargs):
+        next_view = self.request.GET.get("next", f"/{magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME}/")
+        if request.user.is_authenticated:
+            return redirect(next_view)
+
+        return super(LoginView, self).get(request, *args, **kwargs)
+
     def get_context_data(self, **kwargs):
         context = super(LoginView, self).get_context_data(**kwargs)
         context[

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -86,7 +86,8 @@ class ValidateTokenView(View):
         rule_for_redirect = re.compile("(.*next=)(.*)")
         next_view = rule_for_redirect.match(full_path)
         redirect_default = reverse_lazy(magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME)
-        url = next_view.group(1) if next_view else redirect_default
+        url = next_view.group(2) if next_view else redirect_default
+
         logging.warning("## url")
         logging.warning(url)
         if request.user.is_authenticated:

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -26,10 +26,14 @@ class LoginView(FormView):
             "LOGGED_IN_REDIRECT_URL_NAME"
         ] = magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME
         context["LOGOUT_URL_NAME"] = magicauth_settings.LOGOUT_URL_NAME
+        context["next_view"] = self.request.GET.get(
+            "next", f"/{magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME}/"
+        )
         return context
 
-    def form_valid(self, form):
-        form.send_email(self.request)
+    def form_valid(self, form, *args, **kwargs):
+        next_view = self.get_context_data().get("next_view")
+        form.send_email(self.request, next_view)
         return super().form_valid(form)
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-magicauth",
-    version="0.2",
+    version="0.3",
     packages=find_packages(),
     include_package_data=True,
     license="",

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -43,6 +43,7 @@ def test_posting_email_for_valid_existing_user_sends_email(client):
     data = {"email": user.email}
     client.post(url, data=data)
     assert len(mail.outbox) == 1
+    assert "?next=/test_home/" in mail.outbox[0].body
 
 
 def test_posting_unknown_email_does_not_send_email(client):
@@ -67,6 +68,7 @@ def test_opening_magic_link_with_valid_token_redirects(client):
     url = reverse("magicauth-validate-token", args=[token.key])
     response = client.get(url)
     assert response.status_code == 302
+    assert response.url == "/test_home/"
 
 
 def test_token_is_removed_after_visiting_magic_link(client):

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -46,6 +46,15 @@ def test_posting_email_for_valid_existing_user_sends_email(client):
     assert "?next=/test_home/" in mail.outbox[0].body
 
 
+def test_posting_email_for_valid_existing_user_sends_email_and_next_info(client):
+    user = factories.UserFactory()
+    url = reverse("magicauth-login") + "?next=/test_dashboard/"
+    data = {"email": user.email}
+    client.post(url, data=data)
+    assert len(mail.outbox) == 1
+    assert "?next=/test_dashboard/" in mail.outbox[0].body
+
+
 def test_posting_unknown_email_does_not_send_email(client):
     url = reverse("magicauth-login")
     data = {"email": "unknown@email.com"}
@@ -69,6 +78,17 @@ def test_opening_magic_link_with_valid_token_redirects(client):
     response = client.get(url)
     assert response.status_code == 302
     assert response.url == "/test_home/"
+
+
+def test_opening_magic_link_with_a_next_sets_a_new_url(client):
+    token = factories.MagicTokenFactory()
+    url = (
+        reverse("magicauth-validate-token", kwargs={"key": token.key})
+        + "?next=/test_dashboard/"
+    )
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.url == "/test_dashboard/"
 
 
 def test_token_is_removed_after_visiting_magic_link(client):

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -4,12 +4,24 @@ from pytest import mark
 from django.core import mail
 from django.shortcuts import reverse
 from django.utils import timezone
-
 from magicauth.models import MagicToken
 from tests import factories
 
 pytestmark = mark.django_db
 
+
+def test_getting_LoginView_while_authenticated_redirects(client):
+    user = factories.UserFactory()
+    client.force_login(user)
+    url = reverse("magicauth-login")
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.url == "/test_home/"
+
+    url = reverse("magicauth-login") + "?next=/test_dashboard/"
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.url == "/test_dashboard/"
 
 def test_posting_email_for_valid_existing_user_redirects(client):
     user = factories.UserFactory()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,12 +4,17 @@ DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
 
 ROOT_URLCONF = "tests.test_url"
 
-INSTALLED_APPS = ["tests",  "django.contrib.auth", "django.contrib.contenttypes", "magicauth"]
+INSTALLED_APPS = [
+    "tests",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "magicauth",
+]
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 
 MAGICAUTH_FROM_EMAIL = "user@domain.user"
-MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME = "home"
+MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME = "test_home"
 
 
 TEMPLATES = [

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -3,5 +3,7 @@ from django.views.generic import TemplateView
 
 urlpatterns = [
     path("", include("magicauth.urls")),
-    path("test_home/", TemplateView.as_view(template_name="home.html"), name="home"),
+    path(
+        "test_home/", TemplateView.as_view(template_name="home.html"), name="test_home"
+    ),
 ]


### PR DESCRIPTION
Cette PR permet de rediriger les utilisateur post-login.
### Cas n°1 : l'utilisateur demande une page protégée (ex : `monapp.app/accounts/login/?next=page-protégée`)
- Avant : l'utilisateur est redirigé vers la page `MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME` 
- Après :  l'application redirige l'utilisateur vers la page protégée demandée

### Cas n°2 : l'utilisateur se logge sans demander une page spécifique (ex : `monapp.app/accounts/login/`)
- Comportement stable :  l'utilisateur est redirigé vers la page `MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME` 

### Cas n°3 : l'utilisateur est déjà authentifié et accède à `monapp.app/accounts/login/`
-  Avant : l'utilisateur voit un message l'invitant à aller à la page d'accueil
- Après : l'utilisateur est redirigé sur `MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME`

### Cas n°4 : l'utilisateur est déjà authentifié et accède à `monapp.app/accounts/login/?next=page-protégée`
- Avant : l'utilisateur voit un message l'invitant à aller à la page d'accueil
- Après: : l'utilisateur est redirigé sur `page-protégée`