### PR TITLE
Add a WaitView

### DIFF
--- a/magicauth/settings.py
+++ b/magicauth/settings.py
@@ -29,11 +29,18 @@ LOGIN_VIEW_TEMPLATE = getattr(
 EMAIL_SENT_VIEW_TEMPLATE = getattr(
     django_settings, "MAGICAUTH_EMAIL_SENT_VIEW_TEMPLATE", "magicauth/email_sent.html"
 )
+REDIRECT_VIEW_TEMPLATE = getattr(
+    django_settings, "MAGICAUTH_REDIRECT_VIEW_TEMPLATE", "magicauth/redirect_to_home.html"
+)
 
 # URLs for magicauth views
 # Once user has entered email successfully and email has been sent, show this page.
 EMAIL_SENT_URL = getattr(django_settings, "MAGICAUTH_EMAIL_SENT_URL", "email-envoyé/")
 LOGIN_URL = getattr(django_settings, "MAGICAUTH_LOGIN_URL", "login/")
+# The emailed links point to this url, which then redirects to the VALIDATE_TOKEN_URL.
+# The redirection step is there so that antispam email clients do not invalidate the token : they visit all links in
+# email to verify them, so if we didn't have this intermediary url, the token would be invalidated.
+REDIRECT_URL = getattr(django_settings, "MAGICAUTH_REDIRECT_URL", "redirection/")
 # The emailed links point to this url.
 # The view will look for the token in the "key" variable.
 VALIDATE_TOKEN_URL = getattr(

--- a/magicauth/settings.py
+++ b/magicauth/settings.py
@@ -27,7 +27,8 @@ FROM_EMAIL = getattr(django_settings, "MAGICAUTH_FROM_EMAIL")
 ###########################
 # View templates and urls
 ###########################
-# Login view : the view in which your user enters their email to start the login process.
+# Login view :
+# the view in which your user enters their email to start the login process.
 LOGIN_URL = getattr(django_settings, "MAGICAUTH_LOGIN_URL", "login/")
 LOGIN_VIEW_TEMPLATE = getattr(
     django_settings, "MAGICAUTH_LOGIN_VIEW_TEMPLATE", "magicauth/login.html"
@@ -35,32 +36,36 @@ LOGIN_VIEW_TEMPLATE = getattr(
 # Name of the field in your User model that contains the email
 EMAIL_FIELD = getattr(django_settings, "MAGICAUTH_EMAIL_FIELD", "username")
 
-# Email sent view : shown when the user has entered their email successfully and the email has been sent.
+# Email sent view :
+# shown when the user has entered their email successfully and the email has been sent.
 EMAIL_SENT_VIEW_TEMPLATE = getattr(
     django_settings, "MAGICAUTH_EMAIL_SENT_VIEW_TEMPLATE", "magicauth/email_sent.html"
 )
 EMAIL_SENT_URL = getattr(django_settings, "MAGICAUTH_EMAIL_SENT_URL", "email-envoyé/")
 
-# Redirect view : The emailed links point to this url. It shows a wait message, makes the user wait for
-# REDIRECT_WAIT_SECONDS, and then redirects them to the VALIDATE_TOKEN_URL (see below).
+# Wait view :
+# The emailed links point to this url. It shows a wait message, makes the user wait for
+# WAIT_SECONDS, and then redirects them to the VALIDATE_TOKEN_URL (see below).
 # Why do we have this view? Because some mail clients visit links their find in email, to check them for spam,
 # phishing, etc. So that when the user clicks the link in the email, the antispam bot has already "clicked" it first.
 # Adding this intermediary view avoids having the antispam bot invalidate the token and block the user login : the bot
 # visits the view but does not wait long enough, so the login is not triggered.
-REDIRECT_VIEW_TEMPLATE = getattr(
-    django_settings, "MAGICAUTH_REDIRECT_VIEW_TEMPLATE", "magicauth/redirect_to_home.html"
+WAIT_VIEW_TEMPLATE = getattr(
+    django_settings, "MAGICAUTH_WAIT_VIEW_TEMPLATE", "magicauth/wait.html"
 )
 # The view will look for the token in the "key" variable.
-REDIRECT_URL = getattr(django_settings, "MAGICAUTH_REDIRECT_URL", "redirection/code/<str:key>/")
+WAIT_URL = getattr(django_settings, "MAGICAUTH_WAIT_URL", "chargement/code/<str:key>/")
 
-# Validate token view : validates the token in the url, does the login, and redirects to LOGGED_IN_REDIRECT_URL_NAME.
+# Validate token view :
+# validates the token in the url, does the login, and redirects to LOGGED_IN_REDIRECT_URL_NAME.
 # This view has no template, the user never sees it.
 # The view will look for the token in the "key" variable.
 VALIDATE_TOKEN_URL = getattr(
     django_settings, "MAGICAUTH_VALIDATE_TOKEN_URL", "code/<str:key>/"
 )
 
-# Logged in redirect view : view on which the user lands once logged in. This is a view in your site, probably something
+# Logged in redirect view :
+# view on which the user lands once logged in. This is a view in your site, probably something
 # like "home".
 LOGGED_IN_REDIRECT_URL_NAME = getattr(
     django_settings, "MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME"
@@ -87,7 +92,7 @@ EMAIL_UNKNOWN_CALLBACK = getattr(
 EMAIL_UNKNOWN_MESSAGE = getattr(
     django_settings, "MAGICAUTH_EMAIL_UNKNOWN_MESSAGE", "Aucun utilisateur trouvé."
 )
-# How long the user will wait on the REDIRECT_URL page before doing the actual login.
-REDIRECT_WAIT_SECONDS = getattr(
-    django_settings, "MAGICAUTH_REDIRECT_WAIT_SECONDS", 3
+# How long the user will wait on the WAIT_URL page before doing the actual login.
+WAIT_SECONDS = getattr(
+    django_settings, "MAGICAUTH_WAIT_SECONDS", 3
 )

--- a/magicauth/settings.py
+++ b/magicauth/settings.py
@@ -10,9 +10,11 @@ from django.conf import settings as django_settings
 # https://docs.djangoproject.com/en/2.2/ref/templates/api/#django.template.loaders.app_directories.Loader
 
 # Note 2 : magicauth assumes your logout url name is 'logout'.
-# If it's not, change MAGICAUTH_LOGOUT_URL_NAME in your settings.
+# If it's not, add MAGICAUTH_LOGOUT_URL_NAME in your settings.
 
+#################
 # Email settings
+#################
 EMAIL_SUBJECT = getattr(django_settings, "MAGICAUTH_EMAIL_SUBJECT", "Lien de connexion")
 EMAIL_HTML_TEMPLATE = getattr(
     django_settings, "MAGICAUTH_EMAIL_HTML_TEMPLATE", "magicauth/email.html"
@@ -22,43 +24,54 @@ EMAIL_TEXT_TEMPLATE = getattr(
 )
 FROM_EMAIL = getattr(django_settings, "MAGICAUTH_FROM_EMAIL")
 
-# View templates
+###########################
+# View templates and urls
+###########################
+# Login view : the view in which your user enters their email to start the login process.
+LOGIN_URL = getattr(django_settings, "MAGICAUTH_LOGIN_URL", "login/")
 LOGIN_VIEW_TEMPLATE = getattr(
     django_settings, "MAGICAUTH_LOGIN_VIEW_TEMPLATE", "magicauth/login.html"
 )
+# Name of the field in your User model that contains the email
+EMAIL_FIELD = getattr(django_settings, "MAGICAUTH_EMAIL_FIELD", "username")
+
+# Email sent view : shown when the user has entered their email successfully and the email has been sent.
 EMAIL_SENT_VIEW_TEMPLATE = getattr(
     django_settings, "MAGICAUTH_EMAIL_SENT_VIEW_TEMPLATE", "magicauth/email_sent.html"
 )
+EMAIL_SENT_URL = getattr(django_settings, "MAGICAUTH_EMAIL_SENT_URL", "email-envoyé/")
+
+# Redirect view : The emailed links point to this url. It shows a wait message, makes the user wait for
+# REDIRECT_WAIT_SECONDS, and then redirects them to the VALIDATE_TOKEN_URL (see below).
+# Why do we have this view? Because some mail clients visit links their find in email, to check them for spam,
+# phishing, etc. So that when the user clicks the link in the email, the antispam bot has already "clicked" it first.
+# Adding this intermediary view avoids having the antispam bot invalidate the token and block the user login : the bot
+# visits the view but does not wait long enough, so the login is not triggered.
 REDIRECT_VIEW_TEMPLATE = getattr(
     django_settings, "MAGICAUTH_REDIRECT_VIEW_TEMPLATE", "magicauth/redirect_to_home.html"
 )
-
-# URLs for magicauth views
-# Once user has entered email successfully and email has been sent, show this page.
-EMAIL_SENT_URL = getattr(django_settings, "MAGICAUTH_EMAIL_SENT_URL", "email-envoyé/")
-LOGIN_URL = getattr(django_settings, "MAGICAUTH_LOGIN_URL", "login/")
-# The emailed links point to this url, which then redirects to the VALIDATE_TOKEN_URL.
-# The redirection step is there so that antispam email clients do not invalidate the token : they visit all links in
-# email to verify them, so if we didn't have this intermediary url, the token would be invalidated.
 # The view will look for the token in the "key" variable.
 REDIRECT_URL = getattr(django_settings, "MAGICAUTH_REDIRECT_URL", "redirection/code/<str:key>/")
-# The emailed links point to this url.
+
+# Validate token view : validates the token in the url, does the login, and redirects to LOGGED_IN_REDIRECT_URL_NAME.
+# This view has no template, the user never sees it.
 # The view will look for the token in the "key" variable.
 VALIDATE_TOKEN_URL = getattr(
     django_settings, "MAGICAUTH_VALIDATE_TOKEN_URL", "code/<str:key>/"
 )
 
-# URL names for hooking up magicauth to your site
-# Once user is logged in, redirect to this url (probably your landing page).
+# Logged in redirect view : view on which the user lands once logged in. This is a view in your site, probably something
+# like "home".
 LOGGED_IN_REDIRECT_URL_NAME = getattr(
     django_settings, "MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME"
 )
+
+# Logout view : the url for logout in your site.
 LOGOUT_URL_NAME = getattr(django_settings, "MAGICAUTH_LOGOUT_URL_NAME", "logout")
 
-# Name of the field in your User model that contains the email
-EMAIL_FIELD = getattr(django_settings, "MAGICAUTH_EMAIL_FIELD", "username")
-
-# Other
+#################
+# Other settings
+#################
 # How long a token stays valid.
 # When using an expired token, user will be prompted to get a new one.
 TOKEN_DURATION_SECONDS = getattr(
@@ -74,7 +87,7 @@ EMAIL_UNKNOWN_CALLBACK = getattr(
 EMAIL_UNKNOWN_MESSAGE = getattr(
     django_settings, "MAGICAUTH_EMAIL_UNKNOWN_MESSAGE", "Aucun utilisateur trouvé."
 )
-# How long the user will wait on the "Loading..." page before going to the site. See REDIRECT_URL #todo names
+# How long the user will wait on the REDIRECT_URL page before doing the actual login.
 REDIRECT_WAIT_SECONDS = getattr(
     django_settings, "MAGICAUTH_REDIRECT_WAIT_SECONDS", 3
 )

--- a/magicauth/settings.py
+++ b/magicauth/settings.py
@@ -40,7 +40,8 @@ LOGIN_URL = getattr(django_settings, "MAGICAUTH_LOGIN_URL", "login/")
 # The emailed links point to this url, which then redirects to the VALIDATE_TOKEN_URL.
 # The redirection step is there so that antispam email clients do not invalidate the token : they visit all links in
 # email to verify them, so if we didn't have this intermediary url, the token would be invalidated.
-REDIRECT_URL = getattr(django_settings, "MAGICAUTH_REDIRECT_URL", "redirection/")
+# The view will look for the token in the "key" variable.
+REDIRECT_URL = getattr(django_settings, "MAGICAUTH_REDIRECT_URL", "redirection/code/<str:key>/")
 # The emailed links point to this url.
 # The view will look for the token in the "key" variable.
 VALIDATE_TOKEN_URL = getattr(
@@ -72,4 +73,8 @@ EMAIL_UNKNOWN_CALLBACK = getattr(
 # this message will be displayed when an unknown email is entered.
 EMAIL_UNKNOWN_MESSAGE = getattr(
     django_settings, "MAGICAUTH_EMAIL_UNKNOWN_MESSAGE", "Aucun utilisateur trouvé."
+)
+# How long the user will wait on the "Loading..." page before going to the site. See REDIRECT_URL #todo names
+REDIRECT_WAIT_SECONDS = getattr(
+    django_settings, "MAGICAUTH_REDIRECT_WAIT_SECONDS", 3
 )

--- a/magicauth/templates/magicauth/email.html
+++ b/magicauth/templates/magicauth/email.html
@@ -309,7 +309,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0">
                                   <tbody>
                                     <tr>
-                                      <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-wait' token.key %}">Connexion</a> </td>
+                                      <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_view }}">Connexion</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>

--- a/magicauth/templates/magicauth/email.html
+++ b/magicauth/templates/magicauth/email.html
@@ -309,7 +309,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0">
                                   <tbody>
                                     <tr>
-                                      <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}">Connexion</a> </td>
+                                      <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-wait' token.key %}">Connexion</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>

--- a/magicauth/templates/magicauth/email.txt
+++ b/magicauth/templates/magicauth/email.txt
@@ -1,6 +1,6 @@
 Bonjour {{ user.first_name }} {{ user.last_name }},
 
-Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}?next={{ next_view }}
+Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_view }}
 
 Bonne journée,
 

--- a/magicauth/templates/magicauth/email_sent.html
+++ b/magicauth/templates/magicauth/email_sent.html
@@ -2,22 +2,26 @@
 <html lang="en" dir="ltr">
 <head>
   <link href="https://tabler.github.io/tabler/assets/css/dashboard.css" rel="stylesheet">
+  <style>
+    .flex-column {
+      display: flex;
+      flex-direction: column;
+    }
+  </style>
 </head>
 <body>
   <div class="page">
-    <div class="page-single">
-      <div class="container">
-        <div class="row">
-          <div class="col col-login mx-auto">
-              <div class="card-body p-2">
-                <div class="alert text-center btn-info">
-                  <i class="fe fe-mail" ></i> <i class="fe fe-check" ></i>
-                      <h1>Un email vous a été envoyé pour vous connecter.</h1> Si vous ne le recevez pas, vous pouvez réessayer.
-                </div>
-                <div class="text-center">
-                  <a href="{% url 'magicauth-login' %}?next={{ next_view }}" class="btn btn-secondary">Réessayer</a>
-                </div>
-              </div>
+    <div class="flex-column justify-content-center align-items-center">
+      <div class="card col-login">
+        <div class="card-body flex-column align-items-center bg-info text-white text-center">
+          <div class="mb-4">
+            <i class="fe fe-mail"></i>
+            <i class="fe fe-check"></i>
+          </div>
+          <h1>Un email vous a été envoyé pour vous connecter.</h1>
+          <div class="mb-6">Si vous ne le recevez pas, vous pouvez réessayer.</div>
+          <div>
+            <a href="{% url 'magicauth-login' %}?next={{ next_view }}" class="btn btn-secondary">Réessayer</a>
           </div>
         </div>
       </div>

--- a/magicauth/templates/magicauth/redirect_to_home.html
+++ b/magicauth/templates/magicauth/redirect_to_home.html
@@ -11,7 +11,7 @@
   <script>
     console.log('hello')
     var url = "{{ url }}"
-    var waitSeconds = "{{ wait_seconds }}"
+    var waitSeconds = "{{ REDIRECT_WAIT_SECONDS }}"
 
     setTimeout(function(){
       window.location.replace(url);

--- a/magicauth/templates/magicauth/redirect_to_home.html
+++ b/magicauth/templates/magicauth/redirect_to_home.html
@@ -10,13 +10,11 @@
   </style>
   <script>
     console.log('hello')
-    console.log("{% url 'magicauth-validate-token' 'abcd' %}")
-    console.log("{{ code }}")
-    var code = "{{ code }}"
+    var url = "{{ url }}"
     var waitSeconds = "{{ wait_seconds }}"
 
     setTimeout(function(){
-      alert(code);
+      window.location.replace(url);
     }, waitSeconds * 1000);
 
   </script>

--- a/magicauth/templates/magicauth/redirect_to_home.html
+++ b/magicauth/templates/magicauth/redirect_to_home.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+<head>
+  <link href="https://tabler.github.io/tabler/assets/css/dashboard.css" rel="stylesheet">
+  <style>
+    .flex-column {
+      display: flex;
+      flex-direction: column;
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="flex-column justify-content-center align-items-center">
+      <div class="card col-login">
+        <div class="card-body flex-column align-items-center bg-info text-white">
+          <h1>En chargement...</h1>
+          <div class="mb-6">Veuillez patienter quelques instants</div>
+          <div class="loader"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/magicauth/templates/magicauth/redirect_to_home.html
+++ b/magicauth/templates/magicauth/redirect_to_home.html
@@ -8,6 +8,18 @@
       flex-direction: column;
     }
   </style>
+  <script>
+    console.log('hello')
+    console.log("{% url 'magicauth-validate-token' 'abcd' %}")
+    console.log("{{ code }}")
+    var code = "{{ code }}"
+    var waitSeconds = "{{ wait_seconds }}"
+
+    setTimeout(function(){
+      alert(code);
+    }, waitSeconds * 1000);
+
+  </script>
 </head>
 <body>
   <div class="page">

--- a/magicauth/templates/magicauth/wait.html
+++ b/magicauth/templates/magicauth/wait.html
@@ -11,7 +11,7 @@
   <script>
     console.log('hello')
     var url = "{{ url }}"
-    var waitSeconds = "{{ REDIRECT_WAIT_SECONDS }}"
+    var waitSeconds = "{{ WAIT_SECONDS }}"
 
     setTimeout(function(){
       window.location.replace(url);

--- a/magicauth/templates/magicauth/wait.html
+++ b/magicauth/templates/magicauth/wait.html
@@ -9,10 +9,10 @@
     }
   </style>
   <script>
-    console.log('hello')
-    var url = "{{ url }}"
-    var waitSeconds = "{{ WAIT_SECONDS }}"
+    var url = '{{ url }}'
+    var waitSeconds = {{ WAIT_SECONDS }}
 
+    console.debug('Redirecting to', url, 'in', waitSeconds, 'seconds')
     setTimeout(function(){
       window.location.replace(url);
     }, waitSeconds * 1000);

--- a/magicauth/urls.py
+++ b/magicauth/urls.py
@@ -15,9 +15,9 @@ urlpatterns = [
         name="magicauth-email-sent",
     ),
     path(
-        magicauth_settings.REDIRECT_URL,
-        magicauth_views.RedirectToHomeView.as_view(),
-        name="magicauth-redirect-to-home",
+        magicauth_settings.WAIT_URL,
+        magicauth_views.WaitView.as_view(),
+        name="magicauth-wait",
     ),
     path(
         magicauth_settings.VALIDATE_TOKEN_URL,

--- a/magicauth/urls.py
+++ b/magicauth/urls.py
@@ -15,6 +15,11 @@ urlpatterns = [
         name="magicauth-email-sent",
     ),
     path(
+        magicauth_settings.REDIRECT_URL,
+        magicauth_views.RedirectToHomeView.as_view(),
+        name="magicauth-redirect-to-home",
+    ),
+    path(
         magicauth_settings.VALIDATE_TOKEN_URL,
         magicauth_views.ValidateTokenView.as_view(),
         name="magicauth-validate-token",

--- a/magicauth/utils.py
+++ b/magicauth/utils.py
@@ -1,6 +1,9 @@
 from django import forms
+from django.urls import reverse_lazy
+
 import binascii
 import os
+import re
 
 from . import settings as magicauth_settings
 
@@ -15,3 +18,14 @@ def raise_error(email=None):
     when no user was found in DB during the login process.
     """
     raise forms.ValidationError(magicauth_settings.EMAIL_UNKNOWN_MESSAGE)
+
+
+def get_next_view(request):
+    """
+    Get the next view from the url query parameters (?next=url)
+    """
+    full_path = request.get_full_path()
+    rule_for_redirect = re.compile("(.*next=)(.*)")
+    next_view = rule_for_redirect.match(full_path)
+    redirect_default = reverse_lazy(magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME)
+    return next_view.group(2) if next_view else redirect_default

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -63,6 +63,19 @@ class RedirectToHomeView(TemplateView):
     """
     template_name = magicauth_settings.REDIRECT_VIEW_TEMPLATE
 
+    def get_context_data(self, **kwargs):
+        context = super(RedirectToHomeView, self).get_context_data(**kwargs)
+
+        # todo don't hardcode "code"
+        code = self.request.GET.get("code", "")
+        context['code'] = code
+       # todo send readymade url : {% url 'magicauth-validate-token' token.key %}?next={{ next_view }}
+
+        # todo put that in settings somewhere
+        context['wait_seconds'] = 3
+
+        return context
+
 
 class ValidateTokenView(View):
     """

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -66,12 +66,12 @@ class RedirectToHomeView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(RedirectToHomeView, self).get_context_data(**kwargs)
 
-        # todo don't hardcode "code"
-        code = self.request.GET.get("code", "")
-        context['code'] = code
-       # todo send readymade url : {% url 'magicauth-validate-token' token.key %}?next={{ next_view }}
+        token = self.request.GET.get("code", "") # todo don't hardcode "code". Should it be /code/blah or ?code=blah ?
+        url = f"{reverse_lazy('magicauth-validate-token', kwargs={ 'key': token })}"
+        context["url"] = url
+        # todo what happens if no code?
 
-        # todo put that in settings somewhere
+        # todo put that value in settings somewhere
         context['wait_seconds'] = 3
 
         return context

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -55,6 +55,15 @@ class EmailSentView(TemplateView):
     template_name = magicauth_settings.EMAIL_SENT_VIEW_TEMPLATE
 
 
+class RedirectToHomeView(TemplateView):
+    """
+    The view shows few seconds of wait, and then the user is redirected to home.
+    This is for solving an issue where antispam mail clients visit links in email to check them, and thus invalidate
+    our token.
+    """
+    template_name = magicauth_settings.REDIRECT_VIEW_TEMPLATE
+
+
 class ValidateTokenView(View):
     """
     The link sent by email goes to this view.

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -66,13 +66,12 @@ class RedirectToHomeView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(RedirectToHomeView, self).get_context_data(**kwargs)
 
-        token = self.request.GET.get("code", "") # todo don't hardcode "code". Should it be /code/blah or ?code=blah ?
-        url = f"{reverse_lazy('magicauth-validate-token', kwargs={ 'key': token })}"
+        token_key = kwargs.get("key")
+        url = f"{reverse_lazy('magicauth-validate-token', kwargs={ 'key': token_key })}"
         context["url"] = url
-        # todo what happens if no code?
 
         # todo put that value in settings somewhere
-        context['wait_seconds'] = 3
+        context["REDIRECT_WAIT_SECONDS"] = magicauth_settings.REDIRECT_WAIT_SECONDS
 
         return context
 

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -1,4 +1,3 @@
-import re
 from datetime import timedelta
 from django.contrib import messages
 from django.contrib.auth import login
@@ -9,6 +8,7 @@ from django.views.generic import View, FormView, TemplateView
 from magicauth.forms import EmailForm
 from magicauth.models import MagicToken
 from magicauth import settings as magicauth_settings
+from magicauth.utils import get_next_view
 
 
 class LoginView(FormView):
@@ -63,24 +63,14 @@ class WaitView(TemplateView):
     """
     template_name = magicauth_settings.WAIT_VIEW_TEMPLATE
 
-    # todo : reuse method
-    @staticmethod
-    def get_next_view(request):
-        full_path = request.get_full_path()
-        rule_for_redirect = re.compile("(.*next=)(.*)")
-        next_view = rule_for_redirect.match(full_path)
-        redirect_default = reverse_lazy(magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME)
-        return next_view.group(2) if next_view else redirect_default
-
     def get_context_data(self, **kwargs):
         context = super(WaitView, self).get_context_data(**kwargs)
 
-        next_view = self.get_next_view(self.request)
+        next_view = get_next_view(self.request)
         token_key = kwargs.get("key")
         url = f"{reverse_lazy('magicauth-validate-token', kwargs={ 'key': token_key })}?next={ next_view }"
         context["url"] = url
 
-        # todo put that value in settings somewhere
         context["WAIT_SECONDS"] = magicauth_settings.WAIT_SECONDS
 
         return context
@@ -108,16 +98,8 @@ class ValidateTokenView(View):
             return None
         return token
 
-    @staticmethod
-    def get_next_view(request):
-        full_path = request.get_full_path()
-        rule_for_redirect = re.compile("(.*next=)(.*)")
-        next_view = rule_for_redirect.match(full_path)
-        redirect_default = reverse_lazy(magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME)
-        return next_view.group(2) if next_view else redirect_default
-
     def get(self, request, *args, **kwargs):
-        url = self.get_next_view(request)
+        url = get_next_view(request)
 
         if request.user.is_authenticated:
             return redirect(url)

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -55,23 +55,23 @@ class EmailSentView(TemplateView):
     template_name = magicauth_settings.EMAIL_SENT_VIEW_TEMPLATE
 
 
-class RedirectToHomeView(TemplateView):
+class WaitView(TemplateView):
     """
-    The view shows few seconds of wait, and then the user is redirected to home.
+    The view shows few seconds of wait, and then the user is redirected to login.
     This is for solving an issue where antispam mail clients visit links in email to check them, and thus invalidate
     our token.
     """
-    template_name = magicauth_settings.REDIRECT_VIEW_TEMPLATE
+    template_name = magicauth_settings.WAIT_VIEW_TEMPLATE
 
     def get_context_data(self, **kwargs):
-        context = super(RedirectToHomeView, self).get_context_data(**kwargs)
+        context = super(WaitView, self).get_context_data(**kwargs)
 
         token_key = kwargs.get("key")
         url = f"{reverse_lazy('magicauth-validate-token', kwargs={ 'key': token_key })}"
         context["url"] = url
 
         # todo put that value in settings somewhere
-        context["REDIRECT_WAIT_SECONDS"] = magicauth_settings.REDIRECT_WAIT_SECONDS
+        context["WAIT_SECONDS"] = magicauth_settings.WAIT_SECONDS
 
         return context
 


### PR DESCRIPTION
Problem : some mail clients have an antispam feature where they visit links in emails to check for security problems. For magicauth, it means that by visiting the link, they trigger the auth. When the user clicks the link to login, since the link is usable only once, it is now expired and the user is asked to log in again.

Solution : make the link point to a wait page, which redirects to the login after a few seconds. The antispam program will still visit the link, but it will not stay around for 3 seconds, and thus it will not trigger the login.

This PR 
 - adds the wait page. There is a little JS script included in a <script> tag in the html that does the redirect. I left it directly in the html because for such a small script it's easier. (if ever it gets big and complicated in the future, we can consider moving it out)
 - refactors and documents the settings
 - refactors the email templates to simplify them and make them IE-compatible