### PR TITLE
Add token duration in email

### DIFF
--- a/magicauth/forms.py
+++ b/magicauth/forms.py
@@ -5,7 +5,7 @@ from django.template import loader
 from django.utils.module_loading import import_string
 from magicauth import settings as magicauth_settings
 from magicauth.models import MagicToken
-
+import math
 
 email_unknown_callback = import_string(magicauth_settings.EMAIL_UNKNOWN_CALLBACK)
 
@@ -42,6 +42,8 @@ class EmailForm(forms.Form):
             "user": user,
             "site": current_site,
             "next_view": next_view,
+            "TOKEN_DURATION_MINUTES": math.floor(magicauth_settings.TOKEN_DURATION_SECONDS / 60),
+            "TOKEN_DURATION_SECONDS": magicauth_settings.TOKEN_DURATION_SECONDS,
         }
         text_message = loader.render_to_string(text_template, context)
         html_message = loader.render_to_string(html_template, context)

--- a/magicauth/templates/magicauth/email.html
+++ b/magicauth/templates/magicauth/email.html
@@ -317,6 +317,7 @@
                             </tr>
                           </tbody>
                         </table>
+                        <p>Ce lien n'est valable que {{ TOKEN_DURATION_MINUTES }} minutes. Il est à usage unique.</p>
                         <p>Bonne journée,</p>
                         <p>L'équipe de {{ site.domain }}</p>
                       </td>

--- a/magicauth/templates/magicauth/email.txt
+++ b/magicauth/templates/magicauth/email.txt
@@ -2,6 +2,8 @@ Bonjour {{ user.first_name }} {{ user.last_name }},
 
 Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}?next={{ next_view }}
 
+Ce lien n'est valable que {{ TOKEN_DURATION_MINUTES }} minutes. Il est à usage unique.
+
 Bonne journée,
 
 L'équipe de {{ site.domain }}


### PR DESCRIPTION
It's best for the user to understand how the magic link works : it can only be used once, and expires after a given time.

This PR exposes the TOKEN_DURATION_SECONDS setting in the email templates, and edits the templates accordingly.