### PR TITLE
Mettre à jour les dépendances des tests

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -9,7 +9,7 @@ faker = FakerFactory.create("fr_FR")
 
 
 @register
-class UserFactory(factory.DjangoModelFactory):
+class UserFactory(factory.django.DjangoModelFactory):
     email = factory.LazyFunction(faker.email)
     username = factory.LazyAttribute(lambda a: a.email)
 
@@ -18,7 +18,7 @@ class UserFactory(factory.DjangoModelFactory):
 
 
 @register
-class MagicTokenFactory(factory.DjangoModelFactory):
+class MagicTokenFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
 
     class Meta:

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest
     pytest-django
     django
-    factory_boy
+    factory_boy==2.12.0
     pytest-factoryboy
     flake8
     ipdb

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest
     pytest-django
     django
-    factory_boy==2.12.0
+    factory_boy>=3.0.0
     pytest-factoryboy
     flake8
     ipdb


### PR DESCRIPTION
Les tests ne passent plus sur master suite à une mise à jour majeure de [factory-boy](https://factoryboy.readthedocs.io/en/stable/changelog.html#id3)

## implémentation
J'ai modifié les appels de `DjangoModelFactory` en `django.DjangoModelFactory` 
