### PR TITLE
Make the system resolve authentification before next url

### DIFF
--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -131,8 +131,8 @@ class ValidateTokenView(NextUrlMixin, View):
         return token
 
     def get(self, request, *args, **kwargs):
-        url = self.get_next_url(request)
         if request.user.is_authenticated:
+            url = self.get_next_url(request)
             return redirect(url)
         token_key = kwargs.get("key")
         token = self.get_valid_token(token_key)
@@ -144,6 +144,7 @@ class ValidateTokenView(NextUrlMixin, View):
                 "votre email ci-dessous puis à cliquer sur valider.",
             )
             return redirect("magicauth-login")
+        url = self.get_next_url(request)
         login(self.request, token.user)
         MagicToken.objects.filter(
             user=token.user


### PR DESCRIPTION
## why this PR
My website receives GET request that have the following format : 
`myurl.com/code/509098167b2b98558fcc7db7a0b861cc9750cf40/?vfmq=/efjccf-azeavd/`

In the current system, the `next_url` is resolved before checking the token. So in the case of the above mention request, we get : 
1. Try to resolve next_url
2. Fails
3. Get default_url
4. Resolve token
5. Fails

With the changes in this PR, with a bad token we get : 
4. Resolve token
5. Fails

And if the token is bad, we don't need to resolve the URL.

## Implementation
Next_url is only resolved if : 
- the user is authenticated
- the token is valid

## Notes

This PR is based on the `otp_rebased`branch