### PR TITLE
Met à jour la version de magicauth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-magicauth",
-    version="0.5",
+    version="0.6",
     packages=find_packages(),
     include_package_data=True,
     license="",


### PR DESCRIPTION
Suite au tagging de la `0.6`, cette PR change le numéro de version quand on fait `pip list`