### PR TITLE
Add conditional import for OTPForm

### DIFF
--- a/magicauth/forms.py
+++ b/magicauth/forms.py
@@ -1,13 +1,9 @@
 from django import forms
 from django.contrib.auth import get_user_model
 from django.utils.module_loading import import_string
-from django.core.validators import RegexValidator
-from django.core.exceptions import ValidationError
-
-from django_otp import user_has_device, devices_for_user
 
 from magicauth import settings as magicauth_settings
-from magicauth.models import MagicToken
+
 
 email_unknown_callback = import_string(magicauth_settings.EMAIL_UNKNOWN_CALLBACK)
 
@@ -24,31 +20,3 @@ class EmailForm(forms.Form):
         if not get_user_model().objects.filter(**field_lookup).exists():
             email_unknown_callback(user_email)
         return user_email
-
-
-class OTPForm(forms.Form):
-    OTP_NUM_DIGITS = magicauth_settings.OTP_NUM_DIGITS
-    otp_token = forms.CharField(
-        max_length=OTP_NUM_DIGITS,
-        min_length=OTP_NUM_DIGITS,
-        validators=[RegexValidator(r"^\d{6}$")],
-        label=f"Entrez le code à {OTP_NUM_DIGITS} chiffres généré par votre téléphone ou votre carte OTP",
-        widget=forms.TextInput(attrs={"autocomplete": "off"}),
-    )
-
-    def __init__(self, user, *args, **kwargs):
-        super(OTPForm, self).__init__(*args, **kwargs)
-        self.user = user
-
-    def clean_otp_token(self):
-        otp_token = self.cleaned_data["otp_token"]
-        user = self.user
-        if not user_has_device(user):
-            raise ValidationError("Le système n'a pas trouvé d'appareil (carte OTP ou générateur sur téléphone) pour votre compte. Contactez le support pour en ajouter un.")
-
-        for device in devices_for_user(user):
-            if device.verify_is_allowed() and device.verify_token(otp_token):
-                return otp_token
-
-        raise ValidationError("Ce code n'est pas valide.")
-

--- a/magicauth/otp_forms.py
+++ b/magicauth/otp_forms.py
@@ -1,0 +1,34 @@
+from django import forms
+from django.core.validators import RegexValidator
+from django.core.exceptions import ValidationError
+
+from django_otp import user_has_device, devices_for_user
+
+from magicauth import settings as magicauth_settings
+
+
+class OTPForm(forms.Form):
+    OTP_NUM_DIGITS = magicauth_settings.OTP_NUM_DIGITS
+    otp_token = forms.CharField(
+        max_length=OTP_NUM_DIGITS,
+        min_length=OTP_NUM_DIGITS,
+        validators=[RegexValidator(r"^\d{6}$")],
+        label=f"Entrez le code à {OTP_NUM_DIGITS} chiffres généré par votre téléphone ou votre carte OTP",
+        widget=forms.TextInput(attrs={"autocomplete": "off"}),
+    )
+
+    def __init__(self, user, *args, **kwargs):
+        super(OTPForm, self).__init__(*args, **kwargs)
+        self.user = user
+
+    def clean_otp_token(self):
+        otp_token = self.cleaned_data["otp_token"]
+        user = self.user
+        if not user_has_device(user):
+            raise ValidationError("Le système n'a pas trouvé d'appareil (carte OTP ou générateur sur téléphone) pour votre compte. Contactez le support pour en ajouter un.")
+
+        for device in devices_for_user(user):
+            if device.verify_is_allowed() and device.verify_token(otp_token):
+                return otp_token
+
+        raise ValidationError("Ce code n'est pas valide.")

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -11,10 +11,14 @@ from django.contrib.auth import get_user_model
 from magicauth import settings as magicauth_settings
 from magicauth.forms import EmailForm
 
-from magicauth.forms import EmailForm, OTPForm
 from magicauth.models import MagicToken
 from magicauth.next_url import NextUrlMixin
 from magicauth.send_token import SendTokenMixin
+
+try:
+    from magicauth.otp_forms import OTPForm
+except ImportError:
+    pass  # OTP form class is optional
 
 
 logger = logging.getLogger()
@@ -43,7 +47,8 @@ class LoginView(NextUrlMixin, SendTokenMixin, FormView):
         ] = magicauth_settings.LOGGED_IN_REDIRECT_URL_NAME
         context["LOGOUT_URL_NAME"] = magicauth_settings.LOGOUT_URL_NAME
         context["OTP_enabled"] = magicauth_settings.ENABLE_2FA
-        context["OTP_form"] = OTPForm(self.request.user)
+        if magicauth_settings.ENABLE_2FA:
+            context["OTP_form"] = OTPForm(self.request.user)
         return context
 
     def get_success_url(self, **kwargs):


### PR DESCRIPTION
On projectis that dont use OTP, we dont import the OTPForm because it
brings a dependency to django-otp.