### PR TITLE
Removes deprecated ugettext_lazy in favor of gettext_lazy

### DIFF
--- a/magicauth/models.py
+++ b/magicauth/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .utils import generate_token
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django<4
+django<5
 pytest
 pytest-django
 


### PR DESCRIPTION
Since Django 3 `ugettext_lazy` [has been deprecated](https://docs.djangoproject.com/en/4.0/releases/3.0/#id3):

> django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(), ungettext(), and ungettext_lazy() are deprecated in favor of the functions that they’re aliases for: [django.utils.translation.gettext()](https://docs.djangoproject.com/en/4.0/ref/utils/#django.utils.translation.gettext), [gettext_lazy()](https://docs.djangoproject.com/en/4.0/ref/utils/#django.utils.translation.gettext_lazy), [gettext_noop()](https://docs.djangoproject.com/en/4.0/ref/utils/#django.utils.translation.gettext_noop), [ngettext()](https://docs.djangoproject.com/en/4.0/ref/utils/#django.utils.translation.ngettext), and [ngettext_lazy()](https://docs.djangoproject.com/en/4.0/ref/utils/#django.utils.translation.ngettext_lazy).

I noticed other functions that were deprecated on v3 as well have been already removed ([example here](https://github.com/betagouv/django-magicauth/blob/master/magicauth/next_url.py#L9)) 

This tiny PR replaces the deprecated version (removed in Django 4) for the supported one. This also means Django 4 is supported (tested on my side, but a second pair of eyes would be greatly appreciated :eyes:) CC: https://github.com/betagouv/django-magicauth/issues/47 CC @hfroot