### PR TITLE
Annulation de la modification betagouv/django-magicauth#51

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ MIDDLEWARE = [
 ]
 ```
 
-7. Configure the projet's domain name using the `Site` model and, if needed, the corresponding `SITE_ID`.
-If you dont configure the domain name, it will default to the URL path.
-
-
 ## Two-Factor Authentication (2FA) using One Time Passwords (OTP)
 
 Two-Factor Authentication means you ask for two different passwords from your user : their normal password and an OTP. (See https://en.wikipedia.org/wiki/Multi-factor_authentication)

--- a/magicauth/send_token.py
+++ b/magicauth/send_token.py
@@ -1,7 +1,6 @@
 import math
 
 from django.contrib.auth import get_user_model
-from django.contrib.sites.models import Site
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.mail import send_mail
 from django.template import loader
@@ -38,17 +37,11 @@ class SendTokenMixin(object):
         html_template = magicauth_settings.EMAIL_HTML_TEMPLATE
         text_template = magicauth_settings.EMAIL_TEXT_TEMPLATE
         from_email = magicauth_settings.FROM_EMAIL
-        try:
-            site_domain = get_current_site(self.request).domain
-        except Site.DoesNotExist:
-            site_domain = self.request.get_host()
         context = {
             "token": token,
             "user": user,
-            "site_domain": site_domain,
-            "TOKEN_DURATION_MINUTES": math.floor(
-                magicauth_settings.TOKEN_DURATION_SECONDS / 60
-            ),
+            "site": get_current_site(self.request),
+            "TOKEN_DURATION_MINUTES": math.floor(magicauth_settings.TOKEN_DURATION_SECONDS / 60),
             "TOKEN_DURATION_SECONDS": magicauth_settings.TOKEN_DURATION_SECONDS,
         }
         if extra_context:

--- a/magicauth/templates/magicauth/email.html
+++ b/magicauth/templates/magicauth/email.html
@@ -301,7 +301,7 @@
                     <tr>
                       <td>
                         <p>Bonjour {{ user.first_name }} {{ user.last_name }},</p>
-                        <p>Pour accéder à {{ site_domain }}, vous avez juste à cliquer sur ce bouton :</p>
+                        <p>Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce bouton :</p>
                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                           <tbody>
                             <tr>
@@ -309,7 +309,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0">
                                   <tbody>
                                     <tr>
-                                      <td align="center"> <a href="https://{{ site_domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}">Connexion</a> </td>
+                                      <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}">Connexion</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>
@@ -326,11 +326,11 @@
                           </p>
                           <p class="mb-6 align-center">
                             <strong>
-                              https://{{ site_domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}
+                              https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}
                             </strong>
                           </p>
                           <p>Bonne journée,</p>
-                          <p>L'équipe de {{ site_domain }}</p>
+                          <p>L'équipe de {{ site.domain }}</p>
                         </div>
                       </td>
                     </tr>

--- a/magicauth/templates/magicauth/email.txt
+++ b/magicauth/templates/magicauth/email.txt
@@ -1,9 +1,9 @@
 Bonjour {{ user.first_name }} {{ user.last_name }},
 
-Pour accéder à {{ site_domain }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site_domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}
+Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}
 
 Ce lien n'est valable que {{ TOKEN_DURATION_MINUTES }} minutes. Il est à usage unique.
 
 Bonne journée,
 
-L'équipe de {{ site_domain }}
+L'équipe de {{ site.domain }}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,7 +11,6 @@ INSTALLED_APPS = [
     "magicauth",
     "django_otp",
     "django_otp.plugins.otp_static",
-    "django.contrib.sites",
 ]
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
@@ -31,5 +30,3 @@ MIDDLEWARE = [
     "django.contrib.sites.middleware.CurrentSiteMiddleware",
     "django_otp.middleware.OTPMiddleware",
 ]
-
-SITE_ID = 1


### PR DESCRIPTION
La PR betagouv/django-magicauth#51 utilise [le framework Site](https://docs.djangoproject.com/fr/4.0/ref/contrib/sites/) mais il n'est pas déclaré dans les `INSTALLED_APPS`, ce qui laisse aux projets dépendant l'oblgation de le faire sans quoi [toute l'infrastructure casse](https://app.circleci.com/pipelines/github/betagouv/Aidants_Connect/3422/workflows/d3a80d66-c743-4908-b853-56c47331508b/jobs/3422), ce qui est un changement non-rétrocompatible. 

Cette modification a été mergée sans discussion et sans description pour un bénéfice qui n'est pas clair. Aidants Connect n'utilise pas le framework Site à ce jour et nous n'avons pas eu de discussion sur ce sujet. Tant que betagouv/django-magicauth#51 casse le code actuel d'autres projet sans autre modification, je préfère annuler cette modification.