### PR TITLE
Release version 0.11

### DIFF
--- a/docs/releases/0.11.md
+++ b/docs/releases/0.11.md
@@ -1,0 +1,5 @@
+=====================
+Django MagicAuth 0.11
+=====================
+
+- Fix rendering bug in i18n

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-magicauth",
-    version="0.10",
+    version="0.11",
     packages=find_packages(),
     include_package_data=True,
     license="",


### PR DESCRIPTION
On a besoin de refaire une MAJ de django-magicauth sur Aidants Connect, car on a déployé le bug introduit dans la version 0.10… 