### PR TITLE
Add support multiple auth backends

### DIFF
--- a/magicauth/settings.py
+++ b/magicauth/settings.py
@@ -76,6 +76,12 @@ LOGGED_IN_REDIRECT_URL_NAME = getattr(
 # Logout view : the url for logout in your site.
 LOGOUT_URL_NAME = getattr(django_settings, "MAGICAUTH_LOGOUT_URL_NAME", "logout")
 
+# The Django authentication backend that magicauth will default to.
+DEFAULT_AUTHENTICATION_BACKEND = getattr(
+    django_settings, "MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND", "django.contrib.auth.backends.ModelBackend2"
+)
+
+
 #################
 # Other settings
 #################

--- a/magicauth/settings.py
+++ b/magicauth/settings.py
@@ -78,7 +78,7 @@ LOGOUT_URL_NAME = getattr(django_settings, "MAGICAUTH_LOGOUT_URL_NAME", "logout"
 
 # The Django authentication backend that magicauth will default to.
 DEFAULT_AUTHENTICATION_BACKEND = getattr(
-    django_settings, "MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND", "django.contrib.auth.backends.ModelBackend2"
+    django_settings, "MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND", "django.contrib.auth.backends.ModelBackend"
 )
 
 

--- a/magicauth/settings.py
+++ b/magicauth/settings.py
@@ -78,7 +78,7 @@ LOGOUT_URL_NAME = getattr(django_settings, "MAGICAUTH_LOGOUT_URL_NAME", "logout"
 
 # The Django authentication backend that magicauth will default to.
 DEFAULT_AUTHENTICATION_BACKEND = getattr(
-    django_settings, "MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND", "django.contrib.auth.backends.ModelBackend"
+    django_settings, "MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND", None
 )
 
 

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -153,16 +153,16 @@ class ValidateTokenView(NextUrlMixin, View):
             )
             return redirect("magicauth-login")
         url = self.get_next_url(request)
-    try:
-        login(self.request, token.user, backend=magicauth_settings.DEFAULT_AUTHENTICATION_BACKEND)
-    except ValueError as e:
-        raise ValueError(
-            "You have multiple authentication backends configured  and therefore must "
-            "set the MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND environement variable in "
-            "in your settings.py. MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND should be a "
-            "dotted import path string."
-        ) from e
-        MagicToken.objects.filter(
-            user=token.user
-        ).delete()  # Remove them all for this user
+        try:
+            login(self.request, token.user, backend=magicauth_settings.DEFAULT_AUTHENTICATION_BACKEND)
+        except ValueError as e:
+            raise ValueError(
+                "You have multiple authentication backends configured and therefore must "
+                "define the MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND setting. "
+                "MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND should be a "
+                "dotted import path string."
+            ) from e
+            MagicToken.objects.filter(
+                user=token.user
+            ).delete()  # Remove them all for this user
         return redirect(url)

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -153,7 +153,7 @@ class ValidateTokenView(NextUrlMixin, View):
             )
             return redirect("magicauth-login")
         url = self.get_next_url(request)
-        login(self.request, token.user, backend="django.contrib.auth.backends.ModelBackend")
+        login(self.request, token.user, backend=magicauth_settings.DEFAULT_AUTHENTICATION_BACKEND)
         MagicToken.objects.filter(
             user=token.user
         ).delete()  # Remove them all for this user

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -153,7 +153,7 @@ class ValidateTokenView(NextUrlMixin, View):
             )
             return redirect("magicauth-login")
         url = self.get_next_url(request)
-        login(self.request, token.user)
+        login(self.request, token.user, backend="django.contrib.auth.backends.ModelBackend")
         MagicToken.objects.filter(
             user=token.user
         ).delete()  # Remove them all for this user

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -153,7 +153,15 @@ class ValidateTokenView(NextUrlMixin, View):
             )
             return redirect("magicauth-login")
         url = self.get_next_url(request)
+    try:
         login(self.request, token.user, backend=magicauth_settings.DEFAULT_AUTHENTICATION_BACKEND)
+    except ValueError as e:
+        raise ValueError(
+            "You have multiple authentication backends configured  and therefore must "
+            "set the MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND environement variable in "
+            "in your settings.py. MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND should be a "
+            "dotted import path string."
+        ) from e
         MagicToken.objects.filter(
             user=token.user
         ).delete()  # Remove them all for this user

--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -162,7 +162,5 @@ class ValidateTokenView(NextUrlMixin, View):
                 "MAGICAUTH_DEFAULT_AUTHENTICATION_BACKEND should be a "
                 "dotted import path string."
             ) from e
-            MagicToken.objects.filter(
-                user=token.user
-            ).delete()  # Remove them all for this user
+        MagicToken.objects.filter(user=token.user).delete()  # Remove them all for this user
         return redirect(url)


### PR DESCRIPTION
We are adding a `backend` parameter to the `login()` to avoid having an error when the projet uses multiple authentication backend.