### PR TITLE
Appeler `form_invalid` sur `self` plutôt que sur `super()` dans `LoginView.form_valid`

### DIFF
--- a/magicauth/views.py
+++ b/magicauth/views.py
@@ -79,7 +79,7 @@ class LoginView(NextUrlMixin, SendTokenMixin, FormView):
             self.send_token(user_email=user_email, extra_context=context)
             return super().form_valid(form)
 
-        return super().form_invalid(form)
+        return self.form_invalid(form)
 
 
 class EmailSentView(NextUrlMixin, TemplateView):


### PR DESCRIPTION
Appeler `form_invalid` sur `super()` dans `LoginView.form_valid` contourne une éventuelle surcharge de `form_invalid` dans une classe fille.