### PR TITLE
Correction du formulaire `OTP_form` effacé du contexte lorsque la requête renvoie une erreur OTP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.2-stretch-browsers
+      - image: cimg/python:3.12.3-browsers
 
     working_directory: ~/repo
 
@@ -12,25 +12,25 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v3-dependencies-{{ checksum "dev-requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v3-dependencies-
 
       - run:
           name: install dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -r requirements.txt
+            python3 -m venv /tmp/venv
+            . /tmp/venv/bin/activate
+            pip install -r dev-requirements.txt
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+            - /tmp/venv
+          key: v3-dependencies-{{ checksum "dev-requirements.txt" }}
 
       - run:
           name: run unit tests
           command: |
-            source venv/bin/activate
+            source /tmp/venv/bin/activate
             tox
 
       - store_artifacts:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,9 @@
+-r requirements.txt
+
 pytest
 pytest-django
-django<4
 factory_boy>=3.0.0
 pytest-factoryboy
 flake8
 ipdb
-django-otp
+tox

--- a/magicauth/otp_forms.py
+++ b/magicauth/otp_forms.py
@@ -7,12 +7,6 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from magicauth.models import MagicToken
-
-try:
-    from django_otp import user_has_device, devices_for_user
-except ImportError:
-    pass
-
 from magicauth import settings as magicauth_settings
 
 
@@ -34,6 +28,8 @@ class OTPForm(forms.Form):
         self.user = user
 
     def clean_otp_token(self):
+        from django_otp import user_has_device, devices_for_user
+
         otp_token = self.cleaned_data["otp_token"]
         user = self.user
         if not user_has_device(user):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,2 @@
 django<5
-pytest
-pytest-django
-
-flake8
-tox
-
+django-otp

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{7,8,9,10,11}
+envlist = py3{8,9,10,11,12}
 skip_missing_interpreters=true
 
 [flake8]


### PR DESCRIPTION
Correction du formulaire `OTP_form` effacé du contexte lorsque la requête renvoie une erreur OTP